### PR TITLE
Add pst CLI calculator with persistent stack and memory slots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pystack"
+version = "0.1.0"
+description = "RPN calculator with a persistent stack and memory slots."
+requires-python = ">=3.12"
+dependencies = ["numpy>=1.26"]
+
+[project.scripts]
+pst = "pystack.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.isort]
+profile = "black"
+line_length = 79
+
+[tool.black]
+line-length = 79

--- a/src/pystack/__init__.py
+++ b/src/pystack/__init__.py
@@ -1,0 +1,3 @@
+from pystack.engine import RpnStack, StackException
+
+__all__ = ["RpnStack", "StackException"]

--- a/src/pystack/__main__.py
+++ b/src/pystack/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from pystack.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pystack/cli.py
+++ b/src/pystack/cli.py
@@ -83,6 +83,7 @@ def _run_repl(conn):
             break
         line = line.strip()
         if not line:
+            _print_stack(stack_items)
             continue
         if line == "exit":
             break

--- a/src/pystack/cli.py
+++ b/src/pystack/cli.py
@@ -1,0 +1,121 @@
+import argparse
+import sys
+
+from pystack.display import format_stack, format_value
+from pystack.engine import RpnStack, StackException
+from pystack.storage import (
+    load_slots,
+    load_stack,
+    open_db,
+    reset_stack,
+    save_slots,
+    save_stack,
+)
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog="pst",
+        description="RPN calculator with persistent stack and slots.",
+    )
+    p.add_argument(
+        "--db",
+        default=None,
+        help="SQLite DB path (default ~/.pystack/pystack.db)",
+    )
+    p.add_argument(
+        "--reset",
+        action="store_true",
+        help="Clear the persisted stack and exit",
+    )
+    p.add_argument(
+        "--slots",
+        action="store_true",
+        help="List memory slots and exit",
+    )
+    p.add_argument(
+        "tokens",
+        nargs="*",
+        help="RPN tokens to execute (omit to enter interactive mode)",
+    )
+    return p
+
+
+def _execute_atomic(stack_items, slots, tokens):
+    rpn = RpnStack(
+        tokens=list(stack_items),
+        raises=True,
+        slots=dict(slots),
+    )
+    rpn.exec(tokens=list(tokens))
+    return list(rpn), rpn.slots
+
+
+def _print_stack(items):
+    out = format_stack(items)
+    if out:
+        print(out)
+
+
+def _run_once(conn, tokens):
+    stack_items = load_stack(conn)
+    slots = load_slots(conn)
+    try:
+        new_stack, new_slots = _execute_atomic(stack_items, slots, tokens)
+    except StackException as e:
+        print(e.msg, file=sys.stderr)
+        return 1
+    save_stack(conn, new_stack)
+    save_slots(conn, new_slots)
+    _print_stack(new_stack)
+    return 0
+
+
+def _run_repl(conn):
+    stack_items = load_stack(conn)
+    slots = load_slots(conn)
+    _print_stack(stack_items)
+    while True:
+        try:
+            line = input("pst> ")
+        except EOFError:
+            print()
+            break
+        line = line.strip()
+        if not line:
+            continue
+        if line == "exit":
+            break
+        tokens = line.split()
+        try:
+            stack_items, slots = _execute_atomic(stack_items, slots, tokens)
+        except StackException as e:
+            print(e.msg, file=sys.stderr)
+            continue
+        save_stack(conn, stack_items)
+        save_slots(conn, slots)
+        _print_stack(stack_items)
+    return 0
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    conn = open_db(args.db)
+    try:
+        if args.reset:
+            reset_stack(conn)
+            return 0
+        if args.slots:
+            slots = load_slots(conn)
+            for name in sorted(slots):
+                print(f"{name} = {format_value(slots[name])}")
+            return 0
+        if args.tokens:
+            return _run_once(conn, args.tokens)
+        return _run_repl(conn)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pystack/display.py
+++ b/src/pystack/display.py
@@ -11,5 +11,11 @@ def format_value(value):
     return repr(value)
 
 
+MAX_VISIBLE = 5
+
+
 def format_stack(items):
+    if len(items) > MAX_VISIBLE:
+        visible = items[-MAX_VISIBLE:]
+        return "\n".join(["..."] + [format_value(v) for v in visible])
     return "\n".join(format_value(v) for v in items)

--- a/src/pystack/display.py
+++ b/src/pystack/display.py
@@ -1,0 +1,15 @@
+import json
+
+
+def format_value(value):
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, (int, float, complex)):
+        return str(value)
+    return repr(value)
+
+
+def format_stack(items):
+    return "\n".join(format_value(v) for v in items)

--- a/src/pystack/engine.py
+++ b/src/pystack/engine.py
@@ -13,11 +13,12 @@ class StackException(Exception):
 
 
 class RpnStack:
-    def __init__(self, tokens=None, raises=False):
+    def __init__(self, tokens=None, raises=False, slots=None):
         self.__stack = []
         self.raises = raises
         if tokens:
             self.__stack.extend(tokens)
+        self.slots = slots if slots is not None else {}
         self.exec_map = {
             "+": self._exec_plus,
             "-": self._exec_minus,
@@ -109,9 +110,10 @@ class RpnStack:
                 self.exception = StackException(
                     f"Syntax Error: {token}", inner=e
                 )
-                self.exception
             except ValueError as e:
                 if not f:
+                    # Unknown token: not a registered op and not a
+                    # valid Python literal. Strings must be quoted.
                     self.exception = StackException(
                         f"Operation not found: {token}", inner=e
                     )
@@ -133,7 +135,7 @@ class RpnStack:
 
     # execute the swap operation
     def _exec_swap(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(b)
         self.push(a)
 
@@ -153,37 +155,37 @@ class RpnStack:
 
     # execute the plus operation
     def _exec_plus(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(a + b)
 
     # execute the mult operation
     def _exec_mult(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(a * b)
 
     # execute the mult operation
     def _exec_power(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(a**b)
 
     # execute the div operation
     def _exec_div(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(a / b)
 
     # execute the floordiv operation
     def _exec_floordiv(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(a // b)
 
     # execute the percent operation
     def _exec_mod(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(a % b)
 
     # execute the minus operation
     def _exec_minus(self):
-        (a, b) = self.__pop_as_list(2)
+        a, b = self.__pop_as_list(2)
         self.push(a - b)
 
     # execute the pick
@@ -252,6 +254,59 @@ class RpnStack:
     def _exec_rolld(self):
         n = self.pop()
         self.__stack[-n:] = [self.__stack[-1]] + self.__stack[-n:-1]
+
+    # convert top of stack to str
+    def _exec_str(self):
+        self.push(str(self.pop()))
+
+    # convert top of stack to int
+    def _exec_int(self):
+        self.push(int(self.pop()))
+
+    # convert top of stack to float
+    def _exec_float(self):
+        self.push(float(self.pop()))
+
+    # store: pop name (string), pop value, slots[name] = value
+    def _exec_sto(self):
+        name = self.pop()
+        value = self.pop()
+        if not isinstance(name, str):
+            self.push(value)
+            self.push(name)
+            raise ValueError(
+                f"sto: slot name must be a string, got "
+                f"{type(name).__name__}"
+            )
+        self.slots[name] = value
+
+    # recall: pop name (string), push slots[name]
+    def _exec_rcl(self):
+        name = self.pop()
+        if not isinstance(name, str):
+            self.push(name)
+            raise ValueError(
+                f"rcl: slot name must be a string, got "
+                f"{type(name).__name__}"
+            )
+        if name not in self.slots:
+            self.push(name)
+            raise KeyError(f"rcl: no such slot {name!r}")
+        self.push(self.slots[name])
+
+    # purge: pop name (string), delete slots[name]
+    def _exec_purge(self):
+        name = self.pop()
+        if not isinstance(name, str):
+            self.push(name)
+            raise ValueError(
+                f"purge: slot name must be a string, got "
+                f"{type(name).__name__}"
+            )
+        if name not in self.slots:
+            self.push(name)
+            raise KeyError(f"purge: no such slot {name!r}")
+        del self.slots[name]
 
     # dups the content of the stack, element by element
     def __iter__(self):

--- a/src/pystack/storage.py
+++ b/src/pystack/storage.py
@@ -1,0 +1,59 @@
+import pickle
+import sqlite3
+from pathlib import Path
+
+DEFAULT_DB_PATH = Path.home() / ".pystack" / "pystack.db"
+
+
+def open_db(path=None):
+    db_path = Path(path) if path else DEFAULT_DB_PATH
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS stack ("
+        "position INTEGER PRIMARY KEY, value BLOB NOT NULL)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS slots ("
+        "name TEXT PRIMARY KEY, value BLOB NOT NULL)"
+    )
+    conn.commit()
+    return conn
+
+
+def load_stack(conn):
+    rows = conn.execute(
+        "SELECT value FROM stack ORDER BY position ASC"
+    ).fetchall()
+    return [pickle.loads(row[0]) for row in rows]
+
+
+def load_slots(conn):
+    rows = conn.execute("SELECT name, value FROM slots").fetchall()
+    return {name: pickle.loads(blob) for name, blob in rows}
+
+
+def save_stack(conn, items):
+    with conn:
+        conn.execute("DELETE FROM stack")
+        conn.executemany(
+            "INSERT INTO stack (position, value) VALUES (?, ?)",
+            [(i, pickle.dumps(v)) for i, v in enumerate(items)],
+        )
+
+
+def save_slots(conn, slots):
+    existing = {row[0] for row in conn.execute("SELECT name FROM slots")}
+    with conn:
+        for name in existing - set(slots):
+            conn.execute("DELETE FROM slots WHERE name = ?", (name,))
+        for name, value in slots.items():
+            conn.execute(
+                "INSERT OR REPLACE INTO slots (name, value) " "VALUES (?, ?)",
+                (name, pickle.dumps(value)),
+            )
+
+
+def reset_stack(conn):
+    with conn:
+        conn.execute("DELETE FROM stack")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,184 @@
+import pytest
+
+from pystack import cli
+from pystack.storage import load_slots, load_stack, open_db
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "pst.db")
+
+
+def run(db, *tokens, capsys):
+    rc = cli.main(["--db", db, *tokens])
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err
+
+
+def read_state(db):
+    conn = open_db(db)
+    try:
+        return load_stack(conn), load_slots(conn)
+    finally:
+        conn.close()
+
+
+# --- core arithmetic + display ------------------------------------------
+
+
+def test_simple_addition_prints_result(db_path, capsys):
+    rc, out, _ = run(db_path, "1", "2", "+", capsys=capsys)
+    assert rc == 0
+    assert out == "3\n"
+
+
+def test_stack_persists_across_invocations(db_path, capsys):
+    run(db_path, "1", "2", "+", capsys=capsys)
+    rc, out, _ = run(db_path, "10", "+", capsys=capsys)
+    assert rc == 0
+    assert out == "13\n"
+
+
+# --- the canonical example sequence from the spec -----------------------
+
+
+def test_replay_example_sequence(db_path, capsys):
+    # Step 1: `pst 1 2 +`        -> 3
+    _, out, _ = run(db_path, "1", "2", "+", capsys=capsys)
+    assert out == "3\n"
+
+    # Step 2: `pst 1`            -> 3, 1
+    _, out, _ = run(db_path, "1", capsys=capsys)
+    assert out == "3\n1\n"
+
+    # Step 3: `pst "'a'"`        -> 3, 1, "a"  (string must be quoted)
+    _, out, _ = run(db_path, "'a'", capsys=capsys)
+    assert out == '3\n1\n"a"\n'
+
+    # Step 4: `pst swap`         -> 3, "a", 1
+    _, out, _ = run(db_path, "swap", capsys=capsys)
+    assert out == '3\n"a"\n1\n'
+
+    # Step 5: `pst str +`        -> 3, "a1"
+    _, out, _ = run(db_path, "str", "+", capsys=capsys)
+    assert out == '3\n"a1"\n'
+
+
+# --- unquoted strings now error ----------------------------------------
+
+
+def test_unquoted_string_errors_and_rolls_back(db_path, capsys):
+    # `pst A` with A not being a command: error, stack unchanged.
+    run(db_path, "1", "2", capsys=capsys)
+    rc, _, err = run(db_path, "A", capsys=capsys)
+    assert rc == 1
+    assert err
+    stack, _ = read_state(db_path)
+    assert stack == [1, 2]
+
+
+# --- explicit coercion idiom -------------------------------------------
+
+
+def test_explicit_str_coercion_for_plus(db_path, capsys):
+    rc, out, _ = run(db_path, "'A'", "1", "str", "+", capsys=capsys)
+    assert rc == 0
+    assert out == '"A1"\n'
+
+
+def test_mixed_plus_errors_and_rolls_back(db_path, capsys):
+    run(db_path, "'a'", "1", capsys=capsys)
+    rc, _, err = run(db_path, "+", capsys=capsys)
+    assert rc == 1
+    assert err
+    # Atomic: stack unchanged after the failing invocation.
+    stack, _ = read_state(db_path)
+    assert stack == ["a", 1]
+
+
+# --- slots --------------------------------------------------------------
+
+
+def test_sto_persists_across_invocations(db_path, capsys):
+    run(db_path, "42", "'x'", "sto", capsys=capsys)
+    rc, out, _ = run(db_path, "'x'", "rcl", capsys=capsys)
+    assert rc == 0
+    assert out == "42\n"
+    _, slots = read_state(db_path)
+    assert slots == {"x": 42}
+
+
+def test_purge_persists(db_path, capsys):
+    run(db_path, "42", "'x'", "sto", capsys=capsys)
+    run(db_path, "'x'", "purge", capsys=capsys)
+    _, slots = read_state(db_path)
+    assert slots == {}
+
+
+# --- flags --------------------------------------------------------------
+
+
+def test_reset_clears_stack_but_not_slots(db_path, capsys):
+    run(db_path, "1", "2", "3", capsys=capsys)
+    run(db_path, "9", "'k'", "sto", capsys=capsys)
+    rc = cli.main(["--db", db_path, "--reset"])
+    capsys.readouterr()
+    assert rc == 0
+    stack, slots = read_state(db_path)
+    assert stack == []
+    assert slots == {"k": 9}
+
+
+def test_slots_flag_lists_slots(db_path, capsys):
+    run(db_path, "1", "'a'", "sto", capsys=capsys)
+    run(db_path, "2", "'b'", "sto", capsys=capsys)
+    rc = cli.main(["--db", db_path, "--slots"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "a = 1" in captured.out
+    assert "b = 2" in captured.out
+
+
+# --- REPL ---------------------------------------------------------------
+
+
+def test_repl_processes_lines_and_exits(db_path, capsys, monkeypatch):
+    inputs = iter(["1 2 +", "swap", "exit"])
+
+    def fake_input(prompt=""):
+        try:
+            return next(inputs)
+        except StopIteration:
+            raise EOFError
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    rc = cli.main(["--db", db_path])
+    capsys.readouterr()
+    assert rc == 0
+    # `1 2 +` -> [3]; then `swap` errors on a 1-element stack and the
+    # state rolls back. Final stack: [3].
+    stack, _ = read_state(db_path)
+    assert stack == [3]
+
+
+def test_repl_atomic_rollback_per_line(db_path, capsys, monkeypatch):
+    run(db_path, "'a'", "1", capsys=capsys)
+    inputs = iter(["+", "exit"])
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt="": next(inputs),
+    )
+    cli.main(["--db", db_path])
+    capsys.readouterr()
+    stack, _ = read_state(db_path)
+    assert stack == ["a", 1]
+
+
+def test_repl_handles_eof(db_path, capsys, monkeypatch):
+    def boom(prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", boom)
+    rc = cli.main(["--db", db_path])
+    capsys.readouterr()
+    assert rc == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,19 @@ def test_repl_atomic_rollback_per_line(db_path, capsys, monkeypatch):
     assert stack == ["a", 1]
 
 
+def test_repl_blank_line_prints_stack(db_path, capsys, monkeypatch):
+    run(db_path, "1", "2", "+", capsys=capsys)
+    inputs = iter(["", "exit"])
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt="": next(inputs),
+    )
+    cli.main(["--db", db_path])
+    out = capsys.readouterr().out
+    # Stack [3] printed on entry, then again on the blank line.
+    assert out.count("3\n") >= 2
+
+
 def test_repl_handles_eof(db_path, capsys, monkeypatch):
     def boom(prompt=""):
         raise EOFError

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,24 @@ def test_mixed_plus_errors_and_rolls_back(db_path, capsys):
     assert stack == ["a", 1]
 
 
+def test_b1a_compound_example(db_path, capsys):
+    # Equivalent to typing `pst "'a'" "'b'" 1 str + swap +` in bash,
+    # which leaves single-quoted python-string-literal tokens in argv.
+    rc, out, _ = run(
+        db_path,
+        "'a'",
+        "'b'",
+        "1",
+        "str",
+        "+",
+        "swap",
+        "+",
+        capsys=capsys,
+    )
+    assert rc == 0
+    assert out == '"b1a"\n'
+
+
 # --- slots --------------------------------------------------------------
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,36 @@
+from pystack.display import format_stack, format_value
+
+
+def test_format_empty_stack_is_empty_string():
+    assert format_stack([]) == ""
+
+
+def test_format_int():
+    assert format_value(3) == "3"
+
+
+def test_format_float():
+    assert format_value(2.5) == "2.5"
+
+
+def test_format_string_uses_double_quotes():
+    assert format_value("a") == '"a"'
+
+
+def test_format_string_with_space():
+    assert format_value("a b") == '"a b"'
+
+
+def test_format_string_escapes_embedded_quote():
+    # json.dumps semantics: embedded double quotes are escaped.
+    assert format_value('say "hi"') == '"say \\"hi\\""'
+
+
+def test_format_stack_one_per_line_bottom_first():
+    # Bottom of stack first, top last.
+    assert format_stack([3, "a1"]) == '3\n"a1"'
+
+
+def test_format_stack_matches_example_sequence():
+    # Mirrors the example: 3, "a", 1 displayed bottom-to-top.
+    assert format_stack([3, "a", 1]) == '3\n"a"\n1'

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -34,3 +34,21 @@ def test_format_stack_one_per_line_bottom_first():
 def test_format_stack_matches_example_sequence():
     # Mirrors the example: 3, "a", 1 displayed bottom-to-top.
     assert format_stack([3, "a", 1]) == '3\n"a"\n1'
+
+
+def test_format_stack_shows_all_when_exactly_five():
+    assert format_stack([1, 2, 3, 4, 5]) == "1\n2\n3\n4\n5"
+
+
+def test_format_stack_truncates_when_more_than_five():
+    # 7 items: show "..." and the 5 most recent (top of stack).
+    assert format_stack([1, 2, 3, 4, 5, 6, 7]) == "...\n3\n4\n5\n6\n7"
+
+
+def test_format_stack_truncation_keeps_top_at_bottom():
+    items = list(range(10))  # 0..9, top is 9
+    out = format_stack(items)
+    lines = out.splitlines()
+    assert lines[0] == "..."
+    assert lines[-1] == "9"
+    assert len(lines) == 6  # "..." + 5 items

--- a/tests/test_engine_extra.py
+++ b/tests/test_engine_extra.py
@@ -97,6 +97,15 @@ def test_plus_string_and_int_raises():
         s.exec(tokens=["'A'", "1", "+"])
 
 
+def test_b1a_compound_example():
+    # User example: "a" "b" 1 str + swap + -> "b1a"
+    # (Tokens shown here are the python-literal form that survives the
+    # shell when the user invokes `pst "'a'" "'b'" 1 str + swap +`.)
+    s = RpnStack()
+    s.exec(tokens=["'a'", "'b'", "1", "str", "+", "swap", "+"])
+    assert list(s) == ["b1a"]
+
+
 # --- sto / rcl / purge ---------------------------------------------------
 
 

--- a/tests/test_engine_extra.py
+++ b/tests/test_engine_extra.py
@@ -1,0 +1,149 @@
+import pytest
+
+from pystack import RpnStack, StackException
+
+# --- string parsing (strings must be quoted) -----------------------------
+
+
+def test_single_quoted_string_literal_parses():
+    s = RpnStack()
+    s.exec("'hello'")
+    assert list(s) == ["hello"]
+
+
+def test_double_quoted_string_literal_parses():
+    s = RpnStack()
+    s.exec('"hello"')
+    assert list(s) == ["hello"]
+
+
+def test_single_quoted_string_with_spaces_parses():
+    # When the user types `pst "'a b'"`, the shell strips the outer
+    # double quotes; argv carries the token "'a b'", which is a
+    # valid Python string literal and should parse to "a b".
+    s = RpnStack()
+    s.exec("'a b'")
+    assert list(s) == ["a b"]
+
+
+def test_unquoted_unknown_token_errors():
+    # `pst A` with A not being a command: strings must be quoted,
+    # so this is an error rather than a bareword push.
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec("A")
+
+
+# --- str / int / float conversions ---------------------------------------
+
+
+def test_str_of_int():
+    s = RpnStack()
+    s.exec(tokens="42 str".split())
+    assert list(s) == ["42"]
+
+
+def test_str_of_float():
+    s = RpnStack()
+    s.exec(tokens="1.5 str".split())
+    assert list(s) == ["1.5"]
+
+
+def test_int_of_string():
+    s = RpnStack()
+    s.exec(tokens="'7' int".split())
+    assert list(s) == [7]
+
+
+def test_int_of_float():
+    s = RpnStack()
+    s.exec(tokens="3.7 int".split())
+    assert list(s) == [3]
+
+
+def test_float_of_string():
+    s = RpnStack()
+    s.exec(tokens="'2.5' float".split())
+    assert list(s) == [2.5]
+
+
+def test_float_of_int():
+    s = RpnStack()
+    s.exec(tokens="7 float".split())
+    assert list(s) == [7.0]
+
+
+def test_int_of_bad_string_raises():
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec(tokens="'abc' int".split())
+
+
+# --- the explicit-coercion idiom -----------------------------------------
+
+
+def test_quoted_str_then_int_str_plus_concatenates():
+    # User idiom: `pst "'A'" 1 str +` -> "A1". Strings are quoted;
+    # `str` explicitly coerces the int for concatenation.
+    s = RpnStack()
+    s.exec(tokens=["'A'", "1", "str", "+"])
+    assert list(s) == ["A1"]
+
+
+def test_plus_string_and_int_raises():
+    # Strict-Python `+`: mixed types error out.
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec(tokens=["'A'", "1", "+"])
+
+
+# --- sto / rcl / purge ---------------------------------------------------
+
+
+def test_sto_stores_and_clears_stack():
+    s = RpnStack()
+    s.exec(tokens="42 'x' sto".split())
+    assert list(s) == []
+    assert s.slots == {"x": 42}
+
+
+def test_rcl_pushes_stored_value():
+    s = RpnStack()
+    s.exec(tokens="42 'x' sto 'x' rcl".split())
+    assert list(s) == [42]
+
+
+def test_sto_overwrites_existing_slot():
+    s = RpnStack()
+    s.exec(tokens="1 'x' sto 2 'x' sto".split())
+    assert s.slots == {"x": 2}
+
+
+def test_purge_removes_slot():
+    s = RpnStack()
+    s.exec(tokens="42 'x' sto 'x' purge".split())
+    assert s.slots == {}
+
+
+def test_rcl_missing_slot_raises():
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec(tokens="'nope' rcl".split())
+
+
+def test_purge_missing_slot_raises():
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec(tokens="'nope' purge".split())
+
+
+def test_sto_with_non_string_name_raises():
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec(tokens="42 7 sto".split())
+
+
+def test_slots_preserved_across_constructor():
+    s = RpnStack(slots={"y": 99})
+    s.exec(tokens="'y' rcl".split())
+    assert list(s) == [99]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,142 @@
+import numpy as np
+
+from pystack.storage import (
+    load_slots,
+    load_stack,
+    open_db,
+    reset_stack,
+    save_slots,
+    save_stack,
+)
+
+
+def test_open_db_creates_schema(tmp_path):
+    db = tmp_path / "x.db"
+    conn = open_db(db)
+    try:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        assert {"stack", "slots"} <= names
+    finally:
+        conn.close()
+
+
+def test_open_db_creates_parent_directory(tmp_path):
+    db = tmp_path / "a" / "b" / "x.db"
+    conn = open_db(db)
+    try:
+        assert db.exists()
+    finally:
+        conn.close()
+
+
+def test_stack_round_trip(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        items = [1, "a", 3.5, "a b", [1, 2, 3], {"k": "v"}]
+        save_stack(conn, items)
+        assert load_stack(conn) == items
+    finally:
+        conn.close()
+
+
+def test_stack_order_preserved(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        save_stack(conn, ["bottom", 2, "top"])
+        assert load_stack(conn) == ["bottom", 2, "top"]
+    finally:
+        conn.close()
+
+
+def test_save_stack_overwrites(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        save_stack(conn, [1, 2, 3])
+        save_stack(conn, [4, 5])
+        assert load_stack(conn) == [4, 5]
+    finally:
+        conn.close()
+
+
+def test_save_stack_empty(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        save_stack(conn, [1, 2, 3])
+        save_stack(conn, [])
+        assert load_stack(conn) == []
+    finally:
+        conn.close()
+
+
+def test_reset_stack_clears(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        save_stack(conn, [1, 2, 3])
+        reset_stack(conn)
+        assert load_stack(conn) == []
+    finally:
+        conn.close()
+
+
+def test_slots_round_trip(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        slots = {"x": 42, "y": "hello", "z": [1, 2]}
+        save_slots(conn, slots)
+        assert load_slots(conn) == slots
+    finally:
+        conn.close()
+
+
+def test_save_slots_overwrites_existing_name(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        save_slots(conn, {"x": 1})
+        save_slots(conn, {"x": 2})
+        assert load_slots(conn) == {"x": 2}
+    finally:
+        conn.close()
+
+
+def test_save_slots_drops_missing_names(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        save_slots(conn, {"x": 1, "y": 2})
+        save_slots(conn, {"x": 1})
+        assert load_slots(conn) == {"x": 1}
+    finally:
+        conn.close()
+
+
+def test_storage_persists_across_connections(tmp_path):
+    db = tmp_path / "x.db"
+    conn = open_db(db)
+    save_stack(conn, [1, "a", 2])
+    save_slots(conn, {"x": 99})
+    conn.close()
+
+    conn = open_db(db)
+    try:
+        assert load_stack(conn) == [1, "a", 2]
+        assert load_slots(conn) == {"x": 99}
+    finally:
+        conn.close()
+
+
+def test_storage_round_trips_numpy_array(tmp_path):
+    # pickle handles ndarrays; the engine pushes them, so the DB
+    # must accept them.
+    conn = open_db(tmp_path / "x.db")
+    try:
+        arr = np.array([1.0, 2.0, 3.0])
+        save_stack(conn, [arr])
+        out = load_stack(conn)
+        assert len(out) == 1
+        assert np.array_equal(out[0], arr)
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- New `pst` console script wrapping the existing `RpnStack` engine.
- Persistent stack and HP-48-style memory slots in `~/.pystack/pystack.db` (SQLite + pickle).
- Interactive `pst>` REPL when called with no args; blank Enter re-prints the stack.
- Display shows one value per line (bottom of stack first); truncates with leading `...` when the stack has more than 5 items.
- Engine additions: `str` / `int` / `float` 1-arg coercions; `sto` / `rcl` / `purge` for named slots. Strings must be quoted as Python literals — bare unknown tokens raise.
- Atomic invocations: a failing token leaves the persisted state unchanged.
- 106 tests covering engine ops, storage round-trips, display formatting, the CLI replay sequence, atomic rollback, REPL behavior.

## Test plan

- [ ] `pip install -e .` then `pst 1 2 +` prints `3`.
- [ ] State persists: `pst 1 2 +` then `pst 10 +` prints `13`.
- [ ] Quoted strings work: `pst "'a'" "'b'" 1 str + swap +` prints `"b1a"`.
- [ ] Unquoted bareword errors: `pst A` exits non-zero, stack unchanged.
- [ ] REPL: `pst` opens prompt; blank Enter re-prints; `exit` leaves.
- [ ] Truncation: push 7 items, see `...` followed by the last 5.
- [ ] Slots persist: `pst 42 "'x'" sto`; later `pst "'x'" rcl` -> `42`.
- [ ] `pst --reset` clears stack but leaves slots. `pst --slots` lists slots.
- [ ] `tox` (or `pytest tests/`) is green.

https://claude.ai/code/session_01MVu1GunDv5XNoUZp1FWhYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVu1GunDv5XNoUZp1FWhYJ)_