### PR TITLE
Add `i` constant for the imaginary unit

### DIFF
--- a/src/pystack/engine.py
+++ b/src/pystack/engine.py
@@ -145,6 +145,9 @@ class RpnStack:
     def _exec_pi(self):
         self.push(np.pi)
 
+    def _exec_i(self):
+        self.push(1j)
+
     # execute the size operation
     def _exec_size(self):
         self.push(self.size())

--- a/tests/test_engine_extra.py
+++ b/tests/test_engine_extra.py
@@ -156,3 +156,18 @@ def test_slots_preserved_across_constructor():
     s = RpnStack(slots={"y": 99})
     s.exec(tokens="'y' rcl".split())
     assert list(s) == [99]
+
+
+# --- imaginary unit constant ---------------------------------------------
+
+
+def test_imaginary_unit_pushes_1j():
+    s = RpnStack()
+    s.exec("i")
+    assert list(s) == [1j]
+
+
+def test_imaginary_unit_squared_is_minus_one():
+    s = RpnStack()
+    s.exec(tokens="i i *".split())
+    assert list(s) == [-1 + 0j]


### PR DESCRIPTION
## Summary

- `i` (case-insensitive) pushes `1j` onto the stack, matching the existing `e` and `pi` constants.
- Two unit tests: `i` alone, and `i i *` -> `(-1+0j)`.

## Test plan

- [ ] `pst i` prints `1j`.
- [ ] `pst i i *` prints `(-1+0j)`.
- [ ] `pytest tests/` is green.

https://claude.ai/code/session_01MVu1GunDv5XNoUZp1FWhYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVu1GunDv5XNoUZp1FWhYJ)_