### PR TITLE
Add `undo` command with persistent stack-of-stacks

### DIFF
--- a/src/pystack/cli.py
+++ b/src/pystack/cli.py
@@ -1,15 +1,18 @@
 import argparse
 import sys
+from collections import deque
 
 from pystack.display import format_stack, format_value
-from pystack.engine import RpnStack, StackException
+from pystack.engine import UNDO_MAX, RpnStack, StackException
 from pystack.storage import (
     load_slots,
     load_stack,
+    load_undo,
     open_db,
     reset_stack,
     save_slots,
     save_stack,
+    save_undo,
 )
 
 
@@ -41,14 +44,15 @@ def build_parser():
     return p
 
 
-def _execute_atomic(stack_items, slots, tokens):
+def _execute_atomic(stack_items, slots, undo, tokens):
     rpn = RpnStack(
         tokens=list(stack_items),
         raises=True,
         slots=dict(slots),
+        undo=deque(undo, maxlen=UNDO_MAX),
     )
     rpn.exec(tokens=list(tokens))
-    return list(rpn), rpn.slots
+    return list(rpn), rpn.slots, rpn.undo
 
 
 def _print_stack(items):
@@ -60,13 +64,17 @@ def _print_stack(items):
 def _run_once(conn, tokens):
     stack_items = load_stack(conn)
     slots = load_slots(conn)
+    undo = load_undo(conn)
     try:
-        new_stack, new_slots = _execute_atomic(stack_items, slots, tokens)
+        new_stack, new_slots, new_undo = _execute_atomic(
+            stack_items, slots, undo, tokens
+        )
     except StackException as e:
         print(e.msg, file=sys.stderr)
         return 1
     save_stack(conn, new_stack)
     save_slots(conn, new_slots)
+    save_undo(conn, new_undo)
     _print_stack(new_stack)
     return 0
 
@@ -74,6 +82,7 @@ def _run_once(conn, tokens):
 def _run_repl(conn):
     stack_items = load_stack(conn)
     slots = load_slots(conn)
+    undo = load_undo(conn)
     _print_stack(stack_items)
     while True:
         try:
@@ -89,12 +98,15 @@ def _run_repl(conn):
             break
         tokens = line.split()
         try:
-            stack_items, slots = _execute_atomic(stack_items, slots, tokens)
+            stack_items, slots, undo = _execute_atomic(
+                stack_items, slots, undo, tokens
+            )
         except StackException as e:
             print(e.msg, file=sys.stderr)
             continue
         save_stack(conn, stack_items)
         save_slots(conn, slots)
+        save_undo(conn, undo)
         _print_stack(stack_items)
     return 0
 

--- a/src/pystack/engine.py
+++ b/src/pystack/engine.py
@@ -1,6 +1,9 @@
 import ast
+from collections import deque
 
 import numpy as np
+
+UNDO_MAX = 1024
 
 # Inspired by http://www.quickclose.com.au/tut2.htm
 
@@ -13,12 +16,13 @@ class StackException(Exception):
 
 
 class RpnStack:
-    def __init__(self, tokens=None, raises=False, slots=None):
+    def __init__(self, tokens=None, raises=False, slots=None, undo=None):
         self.__stack = []
         self.raises = raises
         if tokens:
             self.__stack.extend(tokens)
         self.slots = slots if slots is not None else {}
+        self.undo = undo if undo is not None else deque(maxlen=UNDO_MAX)
         self.exec_map = {
             "+": self._exec_plus,
             "-": self._exec_minus,
@@ -74,6 +78,12 @@ class RpnStack:
                 # as if its string was entered as a command
                 # Is this what I want?
                 token = token or self.pop()
+
+                # Snapshot the current stack for `undo`, except when
+                # the operation itself is `undo` (which would be a
+                # self-recording loop).
+                if token.lower() != "undo":
+                    self.undo.append(list(self.__stack))
 
                 # First we check is there is a registered function
                 # or an _exec_ function
@@ -202,6 +212,12 @@ class RpnStack:
     # execute the clear
     def _exec_clear(self):
         self.__stack = []
+
+    # restore the stack to its state before the previous non-undo op
+    def _exec_undo(self):
+        if not self.undo:
+            raise ValueError("undo: nothing to undo")
+        self.__stack = self.undo.pop()
 
     # execute the dup
     def _exec_dup(self):

--- a/src/pystack/storage.py
+++ b/src/pystack/storage.py
@@ -1,6 +1,9 @@
 import pickle
 import sqlite3
+from collections import deque
 from pathlib import Path
+
+from pystack.engine import UNDO_MAX
 
 DEFAULT_DB_PATH = Path.home() / ".pystack" / "pystack.db"
 
@@ -16,6 +19,11 @@ def open_db(path=None):
     conn.execute(
         "CREATE TABLE IF NOT EXISTS slots ("
         "name TEXT PRIMARY KEY, value BLOB NOT NULL)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS undo ("
+        "id INTEGER PRIMARY KEY CHECK (id = 1), "
+        "data BLOB NOT NULL)"
     )
     conn.commit()
     return conn
@@ -57,3 +65,18 @@ def save_slots(conn, slots):
 def reset_stack(conn):
     with conn:
         conn.execute("DELETE FROM stack")
+
+
+def load_undo(conn):
+    row = conn.execute("SELECT data FROM undo WHERE id = 1").fetchone()
+    items = pickle.loads(row[0]) if row else []
+    return deque(items, maxlen=UNDO_MAX)
+
+
+def save_undo(conn, undo):
+    blob = pickle.dumps(list(undo))
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO undo (id, data) VALUES (1, ?)",
+            (blob,),
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -133,6 +133,34 @@ def test_purge_persists(db_path, capsys):
     assert slots == {}
 
 
+# --- undo ---------------------------------------------------------------
+
+
+def test_undo_persists_across_invocations(db_path, capsys):
+    run(db_path, "1", "2", "+", capsys=capsys)
+    rc, out, _ = run(db_path, "undo", capsys=capsys)
+    assert rc == 0
+    assert out == "1\n2\n"
+    stack, _ = read_state(db_path)
+    assert stack == [1, 2]
+
+
+def test_undo_chains_across_invocations(db_path, capsys):
+    run(db_path, "1", "2", "3", capsys=capsys)
+    run(db_path, "undo", capsys=capsys)
+    rc, out, _ = run(db_path, "undo", capsys=capsys)
+    assert rc == 0
+    assert out == "1\n"
+
+
+def test_undo_on_empty_undo_errors_and_rolls_back(db_path, capsys):
+    rc, _, err = run(db_path, "undo", capsys=capsys)
+    assert rc == 1
+    assert err
+    stack, _ = read_state(db_path)
+    assert stack == []
+
+
 # --- flags --------------------------------------------------------------
 
 

--- a/tests/test_engine_undo.py
+++ b/tests/test_engine_undo.py
@@ -1,0 +1,81 @@
+import pytest
+
+from pystack import RpnStack, StackException
+
+
+def test_undo_reverts_last_op():
+    # `1 2 +` -> [3]; undo reverts the `+` -> [1, 2].
+    s = RpnStack()
+    s.exec(tokens="1 2 +".split())
+    assert list(s) == [3]
+    s.exec("undo")
+    assert list(s) == [1, 2]
+
+
+def test_undo_chains_per_token():
+    # Three pushes -> three snapshots; three undos peel them off.
+    s = RpnStack()
+    s.exec(tokens="1 2 3".split())
+    assert list(s) == [1, 2, 3]
+    s.exec("undo")
+    assert list(s) == [1, 2]
+    s.exec("undo")
+    assert list(s) == [1]
+    s.exec("undo")
+    assert list(s) == []
+
+
+def test_undo_doesnt_record_itself():
+    # After `1 2`, the undo deque has snapshots [[], [1]].
+    # First undo pops snapshot [1] -> stack = [1]. The undo op
+    # must NOT push a snapshot for itself; otherwise the next
+    # undo would return [1] again instead of [].
+    s = RpnStack()
+    s.exec(tokens="1 2".split())
+    s.exec("undo")
+    assert list(s) == [1]
+    s.exec("undo")
+    assert list(s) == []
+
+
+def test_undo_on_empty_undo_stack_raises():
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec("undo")
+
+
+def test_undo_capped_at_undo_max_snapshots():
+    # UNDO_MAX + 1 non-undo ops produce UNDO_MAX + 1 snapshots,
+    # but the deque drops the oldest. The pre-push-of-`0` snapshot
+    # is gone, so we can only undo back to stack=[0].
+    from pystack.engine import UNDO_MAX
+
+    s = RpnStack()
+    for i in range(UNDO_MAX + 1):
+        s.exec(str(i))
+    assert len(s.undo) == UNDO_MAX
+    for _ in range(UNDO_MAX):
+        s.exec("undo")
+    assert list(s) == [0]
+
+
+def test_undo_after_failed_op_returns_to_pre_op_state():
+    # `+` on a 1-element stack fails (IndexError) but the snapshot
+    # was already taken; undo restores [1].
+    s = RpnStack()
+    s.exec("1")
+    s.exec("+")  # error, stack unchanged
+    s.exec("undo")
+    assert list(s) == [1]
+
+
+def test_new_op_after_undo_records_a_fresh_snapshot():
+    # No redo support — once undone, the snapshot is gone.
+    # A new op records a fresh snapshot from the restored state.
+    s = RpnStack()
+    s.exec(tokens="1 2 +".split())  # -> [3]
+    s.exec("undo")  # -> [1, 2]
+    s.exec("*")  # -> [2], snapshot of [1, 2] saved
+    assert list(s) == [2]
+    s.exec("undo")  # -> [1, 2]
+    assert list(s) == [1, 2]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,12 +1,16 @@
+from collections import deque
+
 import numpy as np
 
 from pystack.storage import (
     load_slots,
     load_stack,
+    load_undo,
     open_db,
     reset_stack,
     save_slots,
     save_stack,
+    save_undo,
 )
 
 
@@ -138,5 +142,48 @@ def test_storage_round_trips_numpy_array(tmp_path):
         out = load_stack(conn)
         assert len(out) == 1
         assert np.array_equal(out[0], arr)
+    finally:
+        conn.close()
+
+
+def test_undo_round_trip(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        snapshots = deque([[], [1], [1, 2]])
+        save_undo(conn, snapshots)
+        loaded = load_undo(conn)
+        assert list(loaded) == [[], [1], [1, 2]]
+    finally:
+        conn.close()
+
+
+def test_undo_load_returns_empty_deque_when_unset(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        loaded = load_undo(conn)
+        assert list(loaded) == []
+    finally:
+        conn.close()
+
+
+def test_undo_save_overwrites(tmp_path):
+    conn = open_db(tmp_path / "x.db")
+    try:
+        save_undo(conn, deque([[1]]))
+        save_undo(conn, deque([[2], [3]]))
+        assert list(load_undo(conn)) == [[2], [3]]
+    finally:
+        conn.close()
+
+
+def test_undo_persists_across_connections(tmp_path):
+    db = tmp_path / "x.db"
+    conn = open_db(db)
+    save_undo(conn, deque([[1, 2], [1, 2, 3]]))
+    conn.close()
+
+    conn = open_db(db)
+    try:
+        assert list(load_undo(conn)) == [[1, 2], [1, 2, 3]]
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

- Every non-`undo` token first snapshots the current stack onto a hidden deque (maxlen 1024).
- `undo` pops the most recent snapshot and restores it as the live stack.
- The history is persisted in a new `undo` SQLite table, so undo works across CLI invocations.
- Calling `undo` with no history raises (atomic invocation rollback applies).

## Test plan

- [ ] `pst 1 2 +` then `pst undo` -> `1`, `2`.
- [ ] Two `undo`s after `1 2 +` get back to `1`.
- [ ] `pst undo` with no history exits non-zero, stack unchanged.
- [ ] 1024 ops + 1024 undos return to the original state.
- [ ] `pytest tests/` is green.

https://claude.ai/code/session_01MVu1GunDv5XNoUZp1FWhYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVu1GunDv5XNoUZp1FWhYJ)_