### PR TITLE
Add `len` command mirroring Python's built-in

### DIFF
--- a/src/pystack/engine.py
+++ b/src/pystack/engine.py
@@ -252,6 +252,10 @@ class RpnStack:
         n = self.pop()
         self.push(self.__pop_as_list(n))
 
+    # pop top, push Python's len() of it
+    def _exec_len(self):
+        self.push(len(self.pop()))
+
     # execute the drop2
     def _exec_drop2(self):
         self.__stack = self.__stack[:-2]

--- a/tests/test_engine_extra.py
+++ b/tests/test_engine_extra.py
@@ -225,3 +225,36 @@ def test_tolist_not_enough_items_raises():
     s = RpnStack(raises=True)
     with pytest.raises(StackException):
         s.exec(tokens="1 5 tolist".split())
+
+
+# --- len -----------------------------------------------------------------
+
+
+def test_len_of_list():
+    s = RpnStack()
+    s.exec(tokens="1 2 3 3 tolist len".split())
+    assert list(s) == [3]
+
+
+def test_len_of_string():
+    s = RpnStack()
+    s.exec(tokens=["'hello'", "len"])
+    assert list(s) == [5]
+
+
+def test_len_of_empty_list():
+    s = RpnStack()
+    s.exec(tokens="0 tolist len".split())
+    assert list(s) == [0]
+
+
+def test_len_of_tuple_literal():
+    s = RpnStack()
+    s.exec(tokens=["'(1, 2, 3, 4)'", "eval", "len"])
+    assert list(s) == [4]
+
+
+def test_len_of_int_raises():
+    s = RpnStack(raises=True)
+    with pytest.raises(StackException):
+        s.exec(tokens="42 len".split())


### PR DESCRIPTION
## Summary
- New stack op `len`: pops the top and pushes `len(value)`.
- Works for any object Python's built-in `len()` accepts — list, str, tuple, dict, ndarray, etc.
- Non-sized values (e.g. `int`) surface as a `StackException`, consistent with how the engine wraps `TypeError`.

## Test plan
- [x] `pytest -q` (135 → 140 tests, all pass)
- [x] `pst 1 2 2 tolist len` → `2`
- [x] `pst "'hello'" len` → `5`
- [x] `pst 42 len` → reports the type error

🤖 Generated with [Claude Code](https://claude.com/claude-code)